### PR TITLE
refactor: add `getDimension` util

### DIFF
--- a/src/components/field.tsx
+++ b/src/components/field.tsx
@@ -1,15 +1,21 @@
 import React from "react"
-import { DIMENSION } from "../constants"
+import { usePhysics } from "../contexts"
+import { getDimension } from "../utils"
 import "./field.css"
 
-export const Field = ({ children }: { children: React.ReactNode }) => (
-  <div
-    className="field"
-    style={{
-      gridTemplateColumns: `repeat(${DIMENSION}, .5rem)`,
-      gridTemplateRows: `repeat(${DIMENSION}, .5rem)`,
-    }}
-  >
-    {children}
-  </div>
-)
+export const Field = ({ children }: { children: React.ReactNode }) => {
+  const { field } = usePhysics()
+  const dimension = getDimension(field)
+
+  return (
+    <div
+      className="field"
+      style={{
+        gridTemplateColumns: `repeat(${dimension}, .5rem)`,
+        gridTemplateRows: `repeat(${dimension}, .5rem)`,
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/violate-causality.tsx
+++ b/src/components/violate-causality.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react"
 import { useEntropy, usePhysics } from "../contexts"
-import { initField } from "../utils"
-import { DIMENSION, OFF } from "../constants"
+import { getDimension, initField } from "../utils"
+import { OFF } from "../constants"
 import { FieldState } from "../types"
 import "./violate-causality.css"
 
@@ -9,6 +9,7 @@ export const ViolateCausality = () => {
   const { field, transition, violateCausality } = usePhysics()
   const { entropy, setEntropy } = useEntropy()
   const snapshots = useRef<FieldState[]>([])
+  const dimension = getDimension(field)
 
   const toggleEntropy = () => {
     if (!entropy) snapshots.current.push(field)
@@ -21,7 +22,7 @@ export const ViolateCausality = () => {
       const previousSpace = snapshots.current.pop()
       previousSpace && violateCausality(previousSpace)
     } else {
-      violateCausality(initField(DIMENSION))
+      violateCausality(initField(dimension))
     }
   }
 
@@ -34,7 +35,7 @@ export const ViolateCausality = () => {
   const handleClear = () => {
     setEntropy(false)
     snapshots.current = []
-    violateCausality(initField(DIMENSION))
+    violateCausality(initField(dimension))
   }
 
   const extinct = field.every((row) => row.every((charge) => charge === OFF))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,5 @@ import { FieldState } from "./types"
 
 export const initField = (dimension: number): FieldState =>
   Array.from({ length: dimension }, () => new Array(dimension).fill(OFF))
+
+export const getDimension = (field: FieldState): number => field.length


### PR DESCRIPTION
- Gets rid of `DIMENSION` dependency in components.
- Abstracts getting `dimension` from `field`